### PR TITLE
Fix starter packs scroll

### DIFF
--- a/src/components/StarterPack/Main/ProfilesList.tsx
+++ b/src/components/StarterPack/Main/ProfilesList.tsx
@@ -40,7 +40,7 @@ export const ProfilesList = React.forwardRef<SectionRef, ProfilesListProps>(
     ref,
   ) {
     const t = useTheme()
-    const bottomBarOffset = useBottomBarOffset(200)
+    const bottomBarOffset = useBottomBarOffset(300)
     const initialNumToRender = useInitialNumToRender()
     const {currentAccount} = useSession()
     const {data, refetch, isError} = useAllListMembersQuery(listUri)


### PR DESCRIPTION
Before: https://github.com/bluesky-social/social-app/issues/5174

After: 
<img width="418" alt="image" src="https://github.com/user-attachments/assets/ce583a81-2cba-4703-8d35-15eaa1bec455">

I'm not sure how the number 200 was initially calculated, but it definitely needs to be increased here.